### PR TITLE
replaced test meta 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@ SOFTWARE.
       <!-- We need it here for Javadoc compilation -->
       <groupId>org.eolang</groupId>
       <artifactId>eo-runtime</artifactId>
-      <version>0.29.1</version>
+      <version>0.29.4</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -183,7 +183,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.29.1</version>
+        <version>0.29.4</version>
         <executions>
           <execution>
             <id>compile</id>

--- a/src/main/eo/org/eolang/sys/uname.eo
+++ b/src/main/eo/org/eolang/sys/uname.eo
@@ -32,7 +32,6 @@
 #  This object can be implementet by EO. But for now it is impossible
 #  due to failed build on Windows.
 [] > uname
-
   [] > @ /string
 
   # TRUE if it's Windows

--- a/src/test/eo/org/eolang/sys/call-test.eo
+++ b/src/test/eo/org/eolang/sys/call-test.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo-sys
-+junit
 +package org.eolang.sys
++tests
 +version 0.0.0
 
 # Making a syscall 'getpid' and compares the result

--- a/src/test/eo/org/eolang/sys/uname-test.eo
+++ b/src/test/eo/org/eolang/sys/uname-test.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo-sys
-+junit
 +package org.eolang.sys
++tests
 +version 0.0.0
 
 # Checks what is the family of the OS

--- a/src/test/eo/org/eolang/sys/win32-test.eo
+++ b/src/test/eo/org/eolang/sys/win32-test.eo
@@ -23,8 +23,8 @@
 +alias org.eolang.hamcrest.assert-that
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo-sys
-+junit
 +package org.eolang.sys
++tests
 +version 0.0.0
 
 # Making a Win32 'GetCurrentProcessId' function call and compares the result


### PR DESCRIPTION
Closes: #62

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of eo-runtime and eo-maven-plugin to 0.29.4, and adds tests for the sys package. 

### Detailed summary
- Updated eo-runtime and eo-maven-plugin versions to 0.29.4
- Added tests for the sys package, including `uname`, `call`, and `win32` tests.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->