### PR TITLE
#68 Made Rultor avoided pre releases

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -12,6 +12,7 @@ merge:
   script: |
     mvn clean install -Pqulice --errors -Dstyle.color=never
 release:
+  pre: false
   script: |-
     mvn versions:set "-DnewVersion=${tag}" -Dstyle.color=never
     git commit -am "${tag}"


### PR DESCRIPTION
Ref: #68 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a pre-release step to the existing release process. 

### Detailed summary
- Added a `pre: false` flag to disable the pre-release step.
- Modified the `script` section to set the new version and commit it to git.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->